### PR TITLE
OAuth2 Client Credentials Authorization support for HTTP Clients.

### DIFF
--- a/config/configoauth2/README.md
+++ b/config/configoauth2/README.md
@@ -1,0 +1,31 @@
+# OAuth2 Client Credential Settings
+
+This module provides HTTP client types to be configured to perform authorization for requests using OAuth2 Client Credentials.
+
+OAuth2 Client Credentials library exposes a [variety of settings](https://pkg.go.dev/golang.org/x/oauth2/clientcredentials)
+and implements the OAuth2.0 ["client credentials"](https://tools.ietf.org/html/rfc6749#section-1.3.4)
+token flow, also known as the "two-legged OAuth 2.0" or machine to machine authorisation. This should be used when the client is acting on its own behalf.
+
+When enabled as a part of HTTP Client Configuration, an HTTP Client with OAuth2 supported authorization transport is returned. The client 
+manages the token auto refresh
+
+## OAuth2 Client Credentials Configuration
+
+- [`client_id`](https://tools.ietf.org/html/rfc6749#section-2.2): The unique identifier issued by authorization server to the registered client.
+- `client_secret`: Registered clients secret.
+- [`token_url`](https://tools.ietf.org/html/rfc6749#section-3.2): endpoint which is used by the client to obtain an access token by
+  presenting its authorization grant or refresh token
+- `scopes`: optional list of requested resource permissions
+
+
+Example:
+```yaml
+exporters:
+  otlphttp:
+    endpoint: http://localhost:9000
+    oauth2:
+      client_id: someclientidentifier
+      client_secret: someclientsecret
+      token_url: https://autz.server/oauth2/default/v1/token
+      scopes: ["some.resource.read"]
+```

--- a/config/configoauth2/configoauth2client.go
+++ b/config/configoauth2/configoauth2client.go
@@ -1,0 +1,69 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configoauth2
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
+)
+
+var (
+	errNoClientIDProvided     = errors.New("no ClientID provided in OAuth Client Credentials configuration")
+	errNoTokenURLProvided     = errors.New("no TokenURL provided in OAuth Client Credentials configuration")
+	errNoClientSecretProvided = errors.New("no ClientSecret provided in OAuth Client Credentials configuration")
+)
+
+// OAuth2ClientCredentials stores the configuration for OAuth2 Client Credentials (2-legged OAuth2 flow) setup
+type OAuth2ClientCredentials struct {
+	// ClientID is the application's ID.
+	ClientID string `mapstructure:"client_id"`
+
+	// ClientSecret is the application's secret.
+	ClientSecret string `mapstructure:"client_secret"`
+
+	// TokenURL is the resource server's token endpoint
+	// URL. This is a constant specific to each server.
+	TokenURL string `mapstructure:"token_url"`
+
+	// Scope specifies optional requested permissions.
+	Scopes []string `mapstructure:"scopes"`
+}
+
+func (c *OAuth2ClientCredentials) RoundTripper(base http.RoundTripper) (http.RoundTripper, error) {
+	if c.ClientID == "" {
+		return nil, errNoClientIDProvided
+	}
+	if c.ClientSecret == "" {
+		return nil, errNoClientSecretProvided
+	}
+	if c.TokenURL == "" {
+		return nil, errNoTokenURLProvided
+	}
+	config := clientcredentials.Config{
+		ClientID:     c.ClientID,
+		ClientSecret: c.ClientSecret,
+		TokenURL:     c.TokenURL,
+		Scopes:       c.Scopes,
+	}
+
+	return &oauth2.Transport{
+		Source: config.TokenSource(context.Background()),
+		Base:   base,
+	}, nil
+}

--- a/config/configoauth2/configoauth2client_test.go
+++ b/config/configoauth2/configoauth2client_test.go
@@ -1,0 +1,113 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configoauth2
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/oauth2"
+)
+
+func TestOAuth2ClientCredentialsSettings(t *testing.T) {
+	tests := []struct {
+		name        string
+		settings    *OAuth2ClientCredentials
+		shouldError bool
+	}{
+		{
+			name: "all_valid_settings",
+			settings: &OAuth2ClientCredentials{
+				ClientID:     "testclientid",
+				ClientSecret: "testsecret",
+				TokenURL:     "https://test-url/v1/token",
+				Scopes:       []string{"resource.read"},
+			},
+			shouldError: false,
+		},
+		{
+			name: "missing_client_id",
+			settings: &OAuth2ClientCredentials{
+				ClientSecret: "testsecret",
+				TokenURL:     "https://test-url/v1/token",
+				Scopes:       []string{"resource.read"},
+			},
+			shouldError: true,
+		},
+		{
+			name: "missing_client_secret",
+			settings: &OAuth2ClientCredentials{
+				ClientID: "testclientid",
+				TokenURL: "https://test-url/v1/token",
+				Scopes:   []string{"resource.read"},
+			},
+			shouldError: true,
+		},
+		{
+			name: "missing_token_url",
+			settings: &OAuth2ClientCredentials{
+				ClientID:     "testclientid",
+				ClientSecret: "testsecret",
+				Scopes:       []string{"resource.read"},
+			},
+			shouldError: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			baseRoundTripper := &testRoundTripperBase{""}
+			_, err := test.settings.RoundTripper(baseRoundTripper)
+			if test.shouldError {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+type testRoundTripperBase struct {
+	testString string
+}
+
+func (b *testRoundTripperBase) RoundTrip(_ *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func TestOAuth2ClientRoundTripperReturnsOAuth2RoundTripper(t *testing.T) {
+	creds := &OAuth2ClientCredentials{
+		ClientID:     "testclientid",
+		ClientSecret: "testsecret",
+		TokenURL:     "https://test-url/v1/token",
+		Scopes:       []string{"resource.read"},
+	}
+
+	testString := "TestString"
+
+	baseRoundTripper := &testRoundTripperBase{testString}
+	roundTripper, err := creds.RoundTripper(baseRoundTripper)
+	assert.NoError(t, err)
+
+	// test roundTripper is an OAuth RoundTripper
+	oAuth2Transport, ok := roundTripper.(*oauth2.Transport)
+	assert.True(t, ok)
+
+	// test oAuthRoundTripper wrapped the base roundTripper properly
+	wrappedRoundTripper, ok := oAuth2Transport.Base.(*testRoundTripperBase)
+	assert.True(t, ok)
+	assert.Equal(t, wrappedRoundTripper.testString, testString)
+}

--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	go.opencensus.io v0.22.5
 	go.uber.org/atomic v1.7.0
 	go.uber.org/zap v1.16.0
+	golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43
 	golang.org/x/sys v0.0.0-20201214210602-f9fddec55a1e
 	golang.org/x/text v0.3.5
 	google.golang.org/genproto v0.0.0-20200904004341-0bd0a958aa1d


### PR DESCRIPTION
**Description:** 

1. Added support for exporters that use HTTP Clients to use OAuth2 Client credentials workflow (2-legged/machine-to-machine). 
2. When enabled as a part of HTTP Client Configuration, an HTTP Client with OAuth2 supported authorization transport is returned. 
3. The underneath [Go OAuth2](https://pkg.go.dev/github.com/jakub-gawlas/oauth2/clientcredentials) library does the token auto-refresh as necessary. 

Example 

```
exporters:
  otlphttp:
    endpoint: http://localhost:9000
    oauth2:
      client_id: someclientidentifier
      client_secret: someclientsecret
      token_url: https://autz.server/oauth2/default/v1/token
      scopes: ["some.resource.read"]
```


**Testing:** : Added unit tests/functional tests. 

**Documentation:**  Added README for the config

